### PR TITLE
Fix required organization_id field in Team model tests

### DIFF
--- a/tests/factories/team_factories.py
+++ b/tests/factories/team_factories.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 
 from apps.teams.models import Team, TeamMember
 from apps.teams.constants import TeamMemberRole
-from tests.factories.organization_factories import OrganizationMemberFactory
+from tests.factories.organization_factories import OrganizationMemberFactory, OrganizationFactory
 
 
 class TeamFactory(DjangoModelFactory):
@@ -17,6 +17,7 @@ class TeamFactory(DjangoModelFactory):
     class Meta:
         model = Team
 
+    organization = factory.SubFactory(OrganizationFactory)
     title = factory.Sequence(lambda n: f"Fundraising Team {n}")
     description = factory.Faker("sentence", nb_words=6)
     custom_remittance_rate = None  # Usually null, can override

--- a/tests/integration/test_accounts_workflows.py
+++ b/tests/integration/test_accounts_workflows.py
@@ -329,7 +329,7 @@ class TestUserRelationshipWorkflows(TestCase):
         org_member = OrganizationMemberFactory(user=user, organization=org)
 
         # Create team and add user
-        team = TeamFactory()
+        team = TeamFactory(organization=org)
         team_member = TeamMemberFactory(organization_member=org_member, team=team)
 
         # Verify integration

--- a/tests/integration/test_auditlog_workflows.py
+++ b/tests/integration/test_auditlog_workflows.py
@@ -28,6 +28,7 @@ from tests.factories import (
 )
 from tests.factories.entry_factories import EntryFactory
 from tests.factories.team_factories import TeamFactory
+from tests.factories import OrganizationFactory
 
 User = get_user_model()
 
@@ -229,7 +230,8 @@ class TestAuditLogWorkflows(TestCase):
         )
 
         # Simulate team assignment (would be logged by team app)
-        team = TeamFactory()
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
         audit_create(
             user=user,
             action_type="entry_created",  # Using available action type

--- a/tests/integration/test_entry_workflows.py
+++ b/tests/integration/test_entry_workflows.py
@@ -12,17 +12,18 @@ from apps.entries.models import Entry
 from apps.teams.constants import TeamMemberRole
 from apps.teams.models import TeamMember
 from tests.factories import (
+    DisbursementEntryFactory,
+    EntryFactory,
+    FlaggedEntryFactory,
+    IncomeEntryFactory,
+    OrganizationFactory,
+    PendingEntryFactory,
+    RemittanceEntryFactory,
+    TeamCoordinatorFactory,
     TeamFactory,
     TeamMemberFactory,
-    TeamCoordinatorFactory,
     OperationsReviewerFactory,
     WorkspaceAdminMemberFactory,
-    EntryFactory,
-    IncomeEntryFactory,
-    DisbursementEntryFactory,
-    RemittanceEntryFactory,
-    PendingEntryFactory,
-    FlaggedEntryFactory,
     WorkspaceFactory,
     WorkspaceTeamFactory,
 )
@@ -35,8 +36,9 @@ class TestEntrySubmissionWorkflows:
 
     def test_complete_entry_submission_workflow(self):
         """Test complete entry submission by team member."""
-        # Create fundraising team with field agent
-        team = TeamFactory(title="Regional Fundraising Team")
+        # Create organization and fundraising team with field agent
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org, title="Regional Fundraising Team")
         field_agent = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
 
         # Submit financial transaction
@@ -110,8 +112,9 @@ class TestEntryReviewWorkflows:
 
     def test_complete_entry_approval_workflow(self):
         """Test complete entry review and approval process."""
-        # Create team with submitter and coordinator
-        team = TeamFactory()
+        # Create organization and team with submitter and coordinator
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
         submitter = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
         team_coordinator = TeamCoordinatorFactory(team=team)
         
@@ -137,8 +140,9 @@ class TestEntryReviewWorkflows:
 
     def test_entry_rejection_workflow(self):
         """Test entry rejection process."""
-        # Create team with submitter and reviewer
-        team = TeamFactory()
+        # Create organization and team with submitter and reviewer
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
         submitter = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
         team_reviewer = OperationsReviewerFactory(team=team)
         
@@ -163,8 +167,9 @@ class TestEntryReviewWorkflows:
 
     def test_entry_flagging_workflow(self):
         """Test entry flagging for further investigation."""
-        # Create team with submitter and workspace admin
-        team = TeamFactory()
+        # Create organization and team with submitter and workspace admin
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
         submitter = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
         team_admin = WorkspaceAdminMemberFactory(team=team)
         
@@ -193,7 +198,8 @@ class TestEntryReviewWorkflows:
 
     def test_reviewer_authorization_workflow(self):
         """Test that only authorized roles can review entries."""
-        team = TeamFactory()
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
         submitter = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
 
         # Create reviewers with different authorized roles
@@ -293,7 +299,8 @@ class TestEntryBulkOperationWorkflows:
 
     def test_bulk_entry_approval_workflow(self):
         """Test approving multiple entries in bulk."""
-        team = TeamFactory()
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
         submitter = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
         team_coordinator = TeamCoordinatorFactory(team=team)
         coordinator = team_coordinator.organization_member
@@ -326,7 +333,8 @@ class TestEntryBulkOperationWorkflows:
 
     def test_bulk_entry_query_workflow(self):
         """Test querying entries by various criteria."""
-        team = TeamFactory()
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
         submitter1 = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
         submitter2 = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
         
@@ -366,7 +374,8 @@ class TestEntryWorkflowIntegration:
     def test_entry_team_integration_workflow(self):
         """Test how entries integrate with team structure."""
         # Create team with multiple members
-        team = TeamFactory(title="Accounting Team")
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org, title="Accounting Team")
         submitter1 = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
         submitter2 = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
         team_coordinator = TeamCoordinatorFactory(team=team)
@@ -432,7 +441,8 @@ class TestEntryWorkflowIntegration:
 
     def test_entry_review_chain_workflow(self):
         """Test complex review chain with multiple reviewers."""
-        team = TeamFactory()
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
         submitter = TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
         team_reviewer1 = OperationsReviewerFactory(team=team)
         team_reviewer2 = WorkspaceAdminMemberFactory(team=team)

--- a/tests/integration/test_team_workflows.py
+++ b/tests/integration/test_team_workflows.py
@@ -35,6 +35,7 @@ class TestTeamCreationWorkflows:
 
         # Create fundraising team with coordinator
         team = TeamFactory(
+            organization=org,
             title="Downtown Fundraising Team",
             description="Urban fundraising and outreach team",
             team_coordinator=coordinator_member,
@@ -46,6 +47,7 @@ class TestTeamCreationWorkflows:
         assert team.team_coordinator == coordinator_member
         assert team.created_by == coordinator_member
         assert team.team_coordinator.organization == org
+        assert team.organization == org
 
         # Create team member entry for coordinator
         team_member = TeamCoordinatorFactory(
@@ -59,20 +61,25 @@ class TestTeamCreationWorkflows:
 
     def test_team_with_custom_remittance_rate_workflow(self):
         """Test team creation with custom remittance rate."""
+        org = OrganizationFactory()
         team = TeamFactory(
-            title="Elite Fundraising Unit", custom_remittance_rate=Decimal("95.00")
+            organization=org,
+            title="Elite Fundraising Unit", 
+            custom_remittance_rate=Decimal("95.00")
         )
 
         assert team.custom_remittance_rate == Decimal("95.00")
         assert team.title == "Elite Fundraising Unit"
+        assert team.organization == org
 
     def test_team_unique_title_constraint(self):
         """Test that fundraising team titles must be unique across all teams."""
-        TeamFactory(title="North Valley Fundraising Team")
+        org = OrganizationFactory()
+        TeamFactory(organization=org, title="North Valley Fundraising Team")
 
         # Attempting to create another team with same title should fail
         with pytest.raises(IntegrityError):
-            TeamFactory(title="North Valley Fundraising Team")
+            TeamFactory(organization=org, title="North Valley Fundraising Team")
 
 
 @pytest.mark.integration
@@ -84,7 +91,7 @@ class TestTeamMembershipWorkflows:
         """Test adding multiple members with different roles to a team."""
         # Setup
         org = OrganizationFactory()
-        team = TeamFactory()
+        team = TeamFactory(organization=org)
 
         # Create organization members
         coord_org_member = OrganizationMemberFactory(organization=org)
@@ -122,8 +129,9 @@ class TestTeamMembershipWorkflows:
 
     def test_team_member_unique_constraint_workflow(self):
         """Test that organization member can only be added once per team."""
-        team = TeamFactory()
-        org_member = OrganizationMemberFactory()
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
+        org_member = OrganizationMemberFactory(organization=org)
 
         # Add member first time - should succeed
         TeamMemberFactory(team=team, organization_member=org_member)
@@ -134,9 +142,10 @@ class TestTeamMembershipWorkflows:
 
     def test_organization_member_multiple_teams_workflow(self):
         """Test that organization member can be in multiple different teams."""
-        org_member = OrganizationMemberFactory()
-        team1 = TeamFactory(title="West Coast Fundraising")
-        team2 = TeamFactory(title="East Coast Operations")
+        org = OrganizationFactory()
+        org_member = OrganizationMemberFactory(organization=org)
+        team1 = TeamFactory(organization=org, title="West Coast Fundraising")
+        team2 = TeamFactory(organization=org, title="East Coast Operations")
 
         # Add same org member to different teams
         member1 = TeamMemberFactory(
@@ -161,7 +170,7 @@ class TestTeamHierarchyWorkflows:
     def test_team_coordinator_assignment_workflow(self):
         """Test assigning and reassigning team coordinators."""
         org = OrganizationFactory()
-        team = TeamFactory()
+        team = TeamFactory(organization=org)
 
         # Create two potential coordinators
         coord1_org_member = OrganizationMemberFactory(organization=org)
@@ -191,7 +200,8 @@ class TestTeamHierarchyWorkflows:
 
     def test_reviewer_hierarchy_workflow(self):
         """Test that reviewers can review submissions from submitters."""
-        team = TeamFactory()
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
 
         # Create reviewer and submitter
         reviewer = OperationsReviewerFactory(team=team)
@@ -219,9 +229,9 @@ class TestTeamQueryWorkflows:
         coordinator_member = OrganizationMemberFactory(organization=org)
 
         # Create teams with this coordinator
-        team1 = TeamFactory(team_coordinator=coordinator_member)
-        team2 = TeamFactory(team_coordinator=coordinator_member)
-        team3 = TeamFactory()  # Different coordinator
+        team1 = TeamFactory(organization=org, team_coordinator=coordinator_member)
+        team2 = TeamFactory(organization=org, team_coordinator=coordinator_member)
+        team3 = TeamFactory(organization=org)  # Different coordinator
 
         # Query teams by coordinator
         coordinated_teams = Team.objects.filter(team_coordinator=coordinator_member)
@@ -233,7 +243,8 @@ class TestTeamQueryWorkflows:
 
     def test_get_team_members_by_role_workflow(self):
         """Test getting team members filtered by role."""
-        team = TeamFactory()
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org)
 
         # Add members with different roles
         coord = TeamCoordinatorFactory(team=team)
@@ -258,12 +269,13 @@ class TestTeamQueryWorkflows:
 
     def test_get_organization_member_teams_workflow(self):
         """Test getting all teams for a specific organization member."""
-        org_member = OrganizationMemberFactory()
+        org = OrganizationFactory()
+        org_member = OrganizationMemberFactory(organization=org)
 
         # Add to multiple teams with different roles
-        team1 = TeamFactory()
-        team2 = TeamFactory()
-        team3 = TeamFactory()
+        team1 = TeamFactory(organization=org)
+        team2 = TeamFactory(organization=org)
+        team3 = TeamFactory(organization=org)
 
         TeamMemberFactory(
             team=team1, organization_member=org_member, role=TeamMemberRole.SUBMITTER

--- a/tests/integration/test_workspace_workflows.py
+++ b/tests/integration/test_workspace_workflows.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from datetime import date, timedelta
 from django.db import IntegrityError
 
+from apps.teams.constants import TeamMemberRole
 from apps.workspaces.models import Workspace
 from apps.workspaces.constants import StatusChoices
 from tests.factories import (
@@ -21,6 +22,7 @@ from tests.factories import (
     WorkspaceTeamFactory,
     TeamFactory,
     TeamMemberFactory,
+    TeamCoordinatorFactory,
 )
 
 
@@ -105,11 +107,12 @@ class TestWorkspaceTeamManagementWorkflows:
 
     def test_add_multiple_teams_to_workspace_workflow(self):
         """Test adding multiple teams to a workspace."""
-        # Create campaign workspace and fundraising teams
-        workspace = WorkspaceFactory(title="Holiday Campaign 2024")
-        team1 = TeamFactory(title="Door-to-Door Fundraising")
-        team2 = TeamFactory(title="Digital Outreach Team")
-        team3 = TeamFactory(title="Corporate Partnership Team")
+        # Create organization, campaign workspace and fundraising teams
+        org = OrganizationFactory()
+        workspace = WorkspaceFactory(title="Holiday Campaign 2024", organization=org)
+        team1 = TeamFactory(organization=org, title="Door-to-Door Fundraising")
+        team2 = TeamFactory(organization=org, title="Digital Outreach Team")
+        team3 = TeamFactory(organization=org, title="Corporate Partnership Team")
 
         # Add teams to workspace
         WorkspaceTeamFactory(workspace=workspace, team=team1)
@@ -132,9 +135,10 @@ class TestWorkspaceTeamManagementWorkflows:
 
     def test_team_multiple_workspaces_workflow(self):
         """Test that a team can be assigned to multiple workspaces."""
-        team = TeamFactory(title="Shared Team")
-        workspace1 = WorkspaceFactory(title="Workspace Alpha")
-        workspace2 = WorkspaceFactory(title="Workspace Beta")
+        org = OrganizationFactory()
+        team = TeamFactory(organization=org, title="Shared Team")
+        workspace1 = WorkspaceFactory(title="Workspace Alpha", organization=org)
+        workspace2 = WorkspaceFactory(title="Workspace Beta", organization=org)
 
         # Add same team to different workspaces
         wt1 = WorkspaceTeamFactory(workspace=workspace1, team=team)
@@ -155,8 +159,9 @@ class TestWorkspaceTeamManagementWorkflows:
 
     def test_workspace_team_unique_constraint_workflow(self):
         """Test that team can only be added once per workspace."""
-        workspace = WorkspaceFactory()
-        team = TeamFactory()
+        org = OrganizationFactory()
+        workspace = WorkspaceFactory(organization=org)
+        team = TeamFactory(organization=org)
 
         # Add team first time - should succeed
         WorkspaceTeamFactory(workspace=workspace, team=team)
@@ -167,8 +172,9 @@ class TestWorkspaceTeamManagementWorkflows:
 
     def test_remove_team_from_workspace_workflow(self):
         """Test removing team from workspace."""
-        workspace = WorkspaceFactory()
-        team = TeamFactory()
+        org = OrganizationFactory()
+        workspace = WorkspaceFactory(organization=org)
+        team = TeamFactory(organization=org)
         workspace_team = WorkspaceTeamFactory(workspace=workspace, team=team)
 
         # Verify team is in workspace
@@ -255,9 +261,10 @@ class TestWorkspaceBusinessLogicWorkflows:
 
     def test_workspace_remittance_rate_inheritance_workflow(self):
         """Test remittance rate inheritance from workspace to teams."""
-        # Create workspace with custom rate
-        workspace = WorkspaceFactory(remittance_rate=Decimal("88.00"))
-        team = TeamFactory(custom_remittance_rate=None)  # No custom rate
+        # Create organization, workspace with custom rate
+        org = OrganizationFactory()
+        workspace = WorkspaceFactory(organization=org, remittance_rate=Decimal("88.00"))
+        team = TeamFactory(organization=org, custom_remittance_rate=None)  # No custom rate
         WorkspaceTeamFactory(workspace=workspace, team=team)
 
         # Team should inherit workspace rate when no custom rate
@@ -265,7 +272,7 @@ class TestWorkspaceBusinessLogicWorkflows:
         assert team.custom_remittance_rate is None
 
         # Team with custom rate should override
-        custom_team = TeamFactory(custom_remittance_rate=Decimal("95.00"))
+        custom_team = TeamFactory(organization=org, custom_remittance_rate=Decimal("95.00"))
         WorkspaceTeamFactory(workspace=workspace, team=custom_team)
 
         assert custom_team.custom_remittance_rate == Decimal("95.00")
@@ -338,21 +345,27 @@ class TestWorkspaceQueryWorkflows:
 
     def test_get_workspace_teams_with_members_workflow(self):
         """Test getting workspace teams with their members."""
-        workspace = WorkspaceFactory()
-        team = TeamFactory()
+        org = OrganizationFactory()
+        workspace = WorkspaceFactory(organization=org)
+        team = TeamFactory(organization=org)
         WorkspaceTeamFactory(workspace=workspace, team=team)
 
         # Add members to team
-        member1 = TeamMemberFactory(team=team)
-        member2 = TeamMemberFactory(team=team)
+        TeamMemberFactory(team=team, role=TeamMemberRole.SUBMITTER)
+        TeamCoordinatorFactory(team=team)
 
-        # Query workspace teams with members
-        workspace_teams = workspace.workspace_teams.select_related("team").all()
-
+        # Get workspace teams with members
+        workspace_teams = workspace.workspace_teams.all().select_related("team")
+        
         for wt in workspace_teams:
+            # Access team members through team
             team_members = wt.team.members.all()
-            assert member1 in team_members
-            assert member2 in team_members
+            assert team_members.count() == 2
+
+            # Should have different roles
+            roles = [tm.role for tm in team_members]
+            assert TeamMemberRole.SUBMITTER in roles
+            assert TeamMemberRole.TEAM_COORDINATOR in roles
 
     def test_get_admin_workspaces_workflow(self):
         """Test getting all workspaces administered by a member."""


### PR DESCRIPTION
This PR updates integration tests to include the required organization field when creating Team objects. After the recent changes to the Team model making organization a required foreign key, many tests were failing with IntegrityError: null value in column "organization_id" of relation "teams_team" violates not-null constraint.

Fixed the following:

- Updated all TeamFactory usages to include organization parameter
- Ensured proper organization context for team creation in all integration tests
- Fixed import of TeamMemberRole from correct module path

This resolves test failures across team, workspace, account, entry, and auditlog integration tests.