### PR TITLE
ruffFormatted

### DIFF
--- a/apps/entries/utils.py
+++ b/apps/entries/utils.py
@@ -1,5 +1,6 @@
 from apps.core.permissions import OrganizationPermissions, WorkspacePermissions
 
+
 def can_view_org_expense(user, organization):
     """
     Returns True if the user has the permission to view the organization expense.
@@ -13,11 +14,13 @@ def can_add_org_expense(user, organization):
     """
     return user.has_perm(OrganizationPermissions.ADD_ORG_ENTRY, organization)
 
+
 def can_update_org_expense(user, organization):
     """
     Returns True if the user has the permission to update the organization expense.
     """
     return user.has_perm(OrganizationPermissions.CHANGE_ORG_ENTRY, organization)
+
 
 def can_delete_org_expense(user, organization):
     """
@@ -25,17 +28,20 @@ def can_delete_org_expense(user, organization):
     """
     return user.has_perm(OrganizationPermissions.DELETE_ORG_ENTRY, organization)
 
+
 def can_add_workspace_expense(user, workspace):
     """
     Returns True if the user has the permission to add the workspace expense.
     """
     return user.has_perm(WorkspacePermissions.ADD_WORKSPACE_ENTRY, workspace)
 
+
 def can_update_workspace_expense(user, workspace):
     """
     Returns True if the user has the permission to update the workspace expense.
     """
     return user.has_perm(WorkspacePermissions.CHANGE_WORKSPACE_ENTRY, workspace)
+
 
 def can_delete_workspace_expense(user, workspace):
     """

--- a/apps/entries/views/org_expense_views.py
+++ b/apps/entries/views/org_expense_views.py
@@ -21,7 +21,6 @@ from ..forms import (
     CreateOrganizationExpenseEntryForm,
     UpdateOrganizationExpenseEntryForm,
 )
-from apps.core.permissions import OrganizationPermissions
 from apps.core.utils import permission_denied_view
 from apps.core.views.crud_base_views import (
     BaseCreateView,
@@ -35,8 +34,12 @@ from apps.core.views.service_layer_mixins import (
     HtmxRowResponseMixin,
 )
 from ..services import create_entry_with_attachments
-from ..utils import can_view_org_expense, can_add_org_expense, can_update_org_expense, can_delete_org_expense
-
+from ..utils import (
+    can_view_org_expense,
+    can_add_org_expense,
+    can_update_org_expense,
+    can_delete_org_expense,
+)
 
 
 class OrganizationExpenseListView(
@@ -67,7 +70,9 @@ class OrganizationExpenseListView(
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["permissions"] = {
-            "can_add_org_expense": can_add_org_expense(self.request.user, self.organization),
+            "can_add_org_expense": can_add_org_expense(
+                self.request.user, self.organization
+            ),
         }
         if not self.request.htmx:
             pass
@@ -89,7 +94,6 @@ class OrganizationExpenseCreateView(
     context_object_name = CONTEXT_OBJECT_NAME
     table_template_name = "entries/partials/table.html"
 
-    
     def dispatch(self, request, *args, **kwargs):
         if not can_add_org_expense(request.user, self.organization):
             return permission_denied_view(
@@ -142,7 +146,6 @@ class OrganizationExpenseUpdateView(
     modal_template_name = "entries/components/update_modal.html"
     row_template_name = "entries/partials/row.html"
 
-    
     def dispatch(self, request, *args, **kwargs):
         if not can_update_org_expense(request.user, self.organization):
             return permission_denied_view(
@@ -203,7 +206,6 @@ class OrganizationExpenseDeleteView(
     context_object_name = CONTEXT_OBJECT_NAME
     table_template_name = "entries/partials/table.html"
 
-
     def dispatch(self, request, *args, **kwargs):
         if not can_delete_org_expense(request.user, self.organization):
             return permission_denied_view(
@@ -211,7 +213,6 @@ class OrganizationExpenseDeleteView(
                 "You do not have permission to delete organization expenses.",
             )
         return super().dispatch(request, *args, **kwargs)
-    
 
     def get_queryset(self):
         return get_entries(

--- a/apps/entries/views/workspace_expense_views.py
+++ b/apps/entries/views/workspace_expense_views.py
@@ -31,7 +31,12 @@ from apps.core.views.service_layer_mixins import (
     HtmxTableServiceMixin,
     HtmxRowResponseMixin,
 )
-from ..utils import can_add_workspace_expense, can_update_workspace_expense, can_delete_workspace_expense
+from ..utils import (
+    can_add_workspace_expense,
+    can_update_workspace_expense,
+    can_delete_workspace_expense,
+)
+from apps.core.utils import permission_denied_view
 
 
 class WorkspaceExpenseListView(
@@ -53,11 +58,12 @@ class WorkspaceExpenseListView(
         )
 
     def get_context_data(self, **kwargs) -> dict[str, Any]:
-
         context = super().get_context_data(**kwargs)
         context["view"] = "entries"
         context["permissions"] = {
-            "can_add_workspace_expense": can_add_workspace_expense(self.request.user, self.workspace),
+            "can_add_workspace_expense": can_add_workspace_expense(
+                self.request.user, self.workspace
+            ),
         }
         return context
 
@@ -132,7 +138,7 @@ class WorkspaceExpenseUpdateView(
     model = Entry
     form_class = UpdateOrganizationExpenseEntryForm
     modal_template_name = "entries/components/update_modal.html"
-    row_template_name = "entries/partials/row.html",
+    row_template_name = ("entries/partials/row.html",)
 
     def dispatch(self, request, *args, **kwargs):
         if not can_update_workspace_expense(request.user, self.workspace):


### PR DESCRIPTION
Refactor permission utility imports and clean up whitespace in organization and workspace expense views. Ensure consistent formatting for permission checks in context data.