### PR TITLE
Fix/query issues for submitters

### DIFF
--- a/apps/entries/forms.py
+++ b/apps/entries/forms.py
@@ -123,7 +123,7 @@ class CreateWorkspaceTeamEntryForm(BaseEntryForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        
+
         occurred_at = cleaned_data.get("occurred_at")
         today = date.today()
 
@@ -251,7 +251,7 @@ class BaseUpdateEntryForm(BaseEntryForm):
 class UpdateWorkspaceTeamEntryForm(BaseUpdateEntryForm):
     def clean(self):
         cleaned_data = super().clean()
-        
+
         occurred_at = cleaned_data.get("occurred_at")
         today = date.today()
 
@@ -264,7 +264,7 @@ class UpdateWorkspaceTeamEntryForm(BaseUpdateEntryForm):
             raise forms.ValidationError(
                 "Entries can only be submitted during the workspace period."
             )
-        
+
         new_status = cleaned_data.get("status")
         # if new status is 'Approved', user must be OR, OA
         if new_status is EntryStatus.APPROVED:

--- a/apps/entries/selectors.py
+++ b/apps/entries/selectors.py
@@ -46,7 +46,7 @@ def get_entries(
     print(f">>>> team entry types => {team_entry_types}")
 
     filters = Q()
-    
+
     if expense_entry_types:
         expense_filter = Q(entry_type__in=expense_entry_types)
         if workspace:

--- a/apps/entries/views/entry_views.py
+++ b/apps/entries/views/entry_views.py
@@ -300,7 +300,7 @@ class WorkspaceTeamEntryDeleteView(
                 request, "You do not have permission to delete this entry."
             )
         return super().dispatch(request, *args, **kwargs)
-    
+
     # Overriding get_object for a tighter fetch!
     # Entries can't be deleted once their status has been changed.
     # The normal `get_object` just grabs it by PK. This means we *could* fetch

--- a/apps/entries/views/mixins.py
+++ b/apps/entries/views/mixins.py
@@ -102,7 +102,7 @@ class WorkspaceLevelEntryFiltering(TeamLevelEntryFiltering):
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         # Gettting all workspace teams under the current workspace
-        context["team_options"] = self.workspace.workspace_teams.select_related(
+        context["team_options"] = self.workspace.joined_teams.select_related(
             "team"
         ).all()
         # Overriding context values

--- a/apps/invitations/models.py
+++ b/apps/invitations/models.py
@@ -33,7 +33,9 @@ class Invitation(baseModel):
     def is_expired(self):
         print(self.expired_at)
         print(timezone.now())
-        print(f"Expired: {self.expired_at < timezone.now()} | self.expired_at < timezone.now()")
+        print(
+            f"Expired: {self.expired_at < timezone.now()} | self.expired_at < timezone.now()"
+        )
         return self.expired_at < timezone.now()
 
     @property

--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -67,7 +67,7 @@ class OverviewFinanceReportView(
         }
 
     def _get_workspace_context(self, workspace: Workspace):
-        children_qs = workspace.workspace_teams.select_related("team").all()
+        children_qs = workspace.joined_teams.select_related("team").all()
         context_children = []
         # Totals for workspace
         total_income = Decimal("0.00")

--- a/apps/workspaces/selectors.py
+++ b/apps/workspaces/selectors.py
@@ -62,18 +62,17 @@ def get_all_related_workspace_teams(organization, user, group_by_workspace=True)
     )
 
     if not is_owner:
-        
         # Note: TeamMember inherits SoftDeleteModel, so the default manager
         # automatically filters out soft-deleted records. This means `user_team_ids`
         # only includes active members, no need to explicitly filter `deleted_at__isnull=True`.
-        
-        #Get All teams the user is a part of under this organization
+
+        # Get All teams the user is a part of under this organization
         user_team_ids = TeamMember.objects.filter(
             team__organization=organization,
             organization_member__user=user,
-        ).values_list('team_id', flat=True)
+        ).values_list("team_id", flat=True)
 
-        #Get all workspace teams related to the teams the user is a part of
+        # Get all workspace teams related to the teams the user is a part of
         qs = qs.filter(
             Q(workspace__workspace_admin__user=user)
             | Q(workspace__operations_reviewer__user=user)

--- a/apps/workspaces/selectors.py
+++ b/apps/workspaces/selectors.py
@@ -55,7 +55,6 @@ def get_all_related_workspace_teams(organization, user, group_by_workspace=True)
     - Otherwise, filters teams the user is directly involved in
     """
     is_owner = organization.owner and organization.owner.user == user
-    print(f"is_owner => {is_owner}")
     qs = (
         WorkspaceTeam.objects.filter(workspace__organization=organization)
         .select_related("workspace")
@@ -63,11 +62,23 @@ def get_all_related_workspace_teams(organization, user, group_by_workspace=True)
     )
 
     if not is_owner:
+        
+        # Note: TeamMember inherits SoftDeleteModel, so the default manager
+        # automatically filters out soft-deleted records. This means `user_team_ids`
+        # only includes active members, no need to explicitly filter `deleted_at__isnull=True`.
+        
+        #Get All teams the user is a part of under this organization
+        user_team_ids = TeamMember.objects.filter(
+            team__organization=organization,
+            organization_member__user=user,
+        ).values_list('team_id', flat=True)
+
+        #Get all workspace teams related to the teams the user is a part of
         qs = qs.filter(
             Q(workspace__workspace_admin__user=user)
             | Q(workspace__operations_reviewer__user=user)
+            | Q(team__team_id__in=user_team_ids)
             | Q(team__team_coordinator__user=user)
-            | Q(team__members__organization_member__user=user)
         ).distinct()
 
     if not group_by_workspace:

--- a/apps/workspaces/templates/workspace_teams/index_2.html
+++ b/apps/workspaces/templates/workspace_teams/index_2.html
@@ -18,7 +18,7 @@
             <h2 class="text-xl font-semibold text-neutral">{{ workspace.title }}</h2>
 
             <div class="flex flex-wrap gap-2 text-sm">
-              <span class="badge badge-info text-xs">Teams: {{ workspace.workspace_teams.count }}</span>
+              <span class="badge badge-info text-xs">Teams: {{ workspace.joined_teams.count }}</span>
               <span class="badge badge-success text-xs">Admin: {{ workspace.workspace_admin }}</span>
               <span class="badge badge-warning text-xs">Reviewer: {{ workspace.operations_reviewer }}</span>
               <span class="badge badge-accent text-xs">Rate: {{ workspace.remittance_rate }}</span>

--- a/apps/workspaces/views.py
+++ b/apps/workspaces/views.py
@@ -226,7 +226,7 @@ def edit_workspace_view(request, organization_id, workspace_id):
                     if old_remittance_rate != form.cleaned_data["remittance_rate"]:
                         print("Remittance Rate Changed")
                         # Get All Workspace Teams
-                        workspace_teams = workspace.workspace_teams.all()
+                        workspace_teams = workspace.joined_teams.all()
                         print(f"Workspace Teams: {workspace_teams}")
                         # Update Remittance Due Amount of Each Team's Remittance
                         for workspace_team in workspace_teams:

--- a/tests/integration/test_remittance_integration.py
+++ b/tests/integration/test_remittance_integration.py
@@ -714,7 +714,7 @@ class TestRemittancePerformance:
         self.organization = OrganizationFactory()
         self.workspace = WorkspaceFactory(organization=self.organization)
         self.teams = [TeamFactory(organization=self.organization) for _ in range(5)]
-        self.workspace_teams = [
+        self.joined_teams = [
             WorkspaceTeamFactory(workspace=self.workspace, team=team)
             for team in self.teams
         ]
@@ -724,7 +724,7 @@ class TestRemittancePerformance:
         """Test performance with bulk operations."""
         # Create multiple remittances with separate workspace teams
         remittances = []
-        for i, workspace_team in enumerate(self.workspace_teams):
+        for i, workspace_team in enumerate(self.joined_teams):
             for j in range(10):  # 10 remittances per team
                 # Create separate workspace team for each remittance
                 separate_workspace_team = WorkspaceTeamFactory(

--- a/tests/integration/test_workspace_workflows.py
+++ b/tests/integration/test_workspace_workflows.py
@@ -118,7 +118,7 @@ class TestWorkspaceTeamManagementWorkflows:
         WorkspaceTeamFactory(workspace=workspace, team=team3)
 
         # Verify relationships
-        workspace_teams = workspace.workspace_teams.all()
+        workspace_teams = workspace.joined_teams.all()
         assert workspace_teams.count() == 3
 
         team_titles = [wt.team.title for wt in workspace_teams]
@@ -127,9 +127,9 @@ class TestWorkspaceTeamManagementWorkflows:
         assert "Corporate Partnership Team" in team_titles
 
         # Verify reverse relationships
-        assert team1.workspace_teams.filter(workspace=workspace).exists()
-        assert team2.workspace_teams.filter(workspace=workspace).exists()
-        assert team3.workspace_teams.filter(workspace=workspace).exists()
+        assert team1.joined_teams.filter(workspace=workspace).exists()
+        assert team2.joined_teams.filter(workspace=workspace).exists()
+        assert team3.joined_teams.filter(workspace=workspace).exists()
 
     def test_team_multiple_workspaces_workflow(self):
         """Test that a team can be assigned to multiple workspaces."""
@@ -149,7 +149,7 @@ class TestWorkspaceTeamManagementWorkflows:
         assert wt2.team == team
 
         # Team should be in both workspaces
-        team_workspaces = team.workspace_teams.all()
+        team_workspaces = team.joined_teams.all()
         assert team_workspaces.count() == 2
         workspace_ids = [wt.workspace.workspace_id for wt in team_workspaces]
         assert workspace1.workspace_id in workspace_ids
@@ -176,13 +176,13 @@ class TestWorkspaceTeamManagementWorkflows:
         workspace_team = WorkspaceTeamFactory(workspace=workspace, team=team)
 
         # Verify team is in workspace
-        assert workspace.workspace_teams.filter(team=team).exists()
+        assert workspace.joined_teams.filter(team=team).exists()
 
         # Remove team from workspace
         workspace_team.delete()
 
         # Verify team is no longer in workspace
-        assert not workspace.workspace_teams.filter(team=team).exists()
+        assert not workspace.joined_teams.filter(team=team).exists()
 
 
 @pytest.mark.integration
@@ -360,7 +360,7 @@ class TestWorkspaceQueryWorkflows:
         )  # Formerly TeamCoordinatorFactory
 
         # Get workspace teams with members
-        workspace_teams = workspace.workspace_teams.all().select_related("team")
+        workspace_teams = workspace.joined_teams.all().select_related("team")
 
         for wt in workspace_teams:
             # Access team members through team

--- a/tests/unit/test_workspace_factories.py
+++ b/tests/unit/test_workspace_factories.py
@@ -104,11 +104,11 @@ class TestWorkspaceTeamFactories:
         workspace = WorkspaceWithTeamsFactory()
 
         assert isinstance(workspace, Workspace)
-        assert workspace.workspace_teams.count() == 2  # Default count
+        assert workspace.joined_teams.count() == 2  # Default count
 
         # Test with custom team count
         workspace_many_teams = WorkspaceWithTeamsFactory(teams=5)
-        assert workspace_many_teams.workspace_teams.count() == 5
+        assert workspace_many_teams.joined_teams.count() == 5
 
     def test_unique_constraint_respected(self):
         """Test that unique constraint is respected in factories."""


### PR DESCRIPTION
Note on SoftDeleteModel Behavior in Queries

In our models that inherit from SoftDeleteModel, the default manager automatically filters out soft-deleted records (i.e., deleted_at IS NULL). This means:

When querying a soft-delete model directly (e.g., TeamMember.objects.filter(...)), only active (non-deleted) rows are returned.

When using these active rows in joins or filters (e.g., WorkspaceTeam → Team → TeamMember), soft-deleted related objects are automatically ignored, so explicit deleted_at__isnull=True is usually not needed.

In contrast, normal models without soft-delete support will include all records matching the filter, even logically “deleted” ones, unless you manually filter them out.

Takeaway: Queries on soft-delete models behave like they are automatically scoped to active objects, making joins and filters cleaner and safer.